### PR TITLE
Check __pycache__ existence on every subdirectory.

### DIFF
--- a/blender_addon_tester/addon_helper.py
+++ b/blender_addon_tester/addon_helper.py
@@ -108,12 +108,11 @@ def zip_addon(addon: str, addon_dir: str):
             # Move to temp dir
             os.chdir(temp_dir)
 
-            # Clear python cache
-            if os.path.isdir("__pycache__"):
-                shutil.rmtree("__pycache__")
-
             # Write addon content into archive
             for dirname, subdirs, files in os.walk(addon_path):
+                if "__pycache__" in subdirs:
+                    subdirs.remove("__pycache__")
+
                 for filename in files:
                     filename = os.path.join(dirname, filename)
 

--- a/blender_addon_tester/addon_helper.py
+++ b/blender_addon_tester/addon_helper.py
@@ -103,13 +103,14 @@ def zip_addon(addon: str, addon_dir: str):
                 shutil.rmtree(temp_dir)
 
             # Creating the addon under the temp dir with its hierarchy 
-            shutil.copytree(addon_path, temp_dir.joinpath(addon_path.relative_to(addon_path.anchor)))
+            dest_temp_dir = temp_dir.joinpath(addon_path.relative_to(addon_path.anchor))
+            shutil.copytree(addon_path, dest_temp_dir)
 
             # Move to temp dir
             os.chdir(temp_dir)
 
             # Write addon content into archive
-            for dirname, subdirs, files in os.walk(addon_path):
+            for dirname, subdirs, files in os.walk(dest_temp_dir):
                 if "__pycache__" in subdirs:
                     subdirs.remove("__pycache__")
 


### PR DESCRIPTION
The logic to delete \_\_pycache\_\_ directories only checked their existence on the top level temp_dir. If __pycache__ also existed inside a subdirectory (which could happen through interactive debugging sessions through Jaques Lucke's Visual Studio Code addon), running the tests tried to clean up the .pyc file from within \_\_pycache\_\_, Instead of removing the subdirs before zipping, this patch just skips over them while iterating the directory structure.