### PR TITLE
Updated to work with Blender 3.6 and fixed some other bugs

### DIFF
--- a/blender_addon_tester/addon_helper.py
+++ b/blender_addon_tester/addon_helper.py
@@ -118,7 +118,7 @@ def zip_addon(addon: str, addon_dir: str):
                     filename = os.path.join(dirname, filename)
 
                     # Clean file
-                    clean_file(filename)
+                    #clean_file(filename)
 
                     # Write file into zip under its hierarchy
                     zf.write(filename, arcname=os.path.relpath(filename, addon_path.parent))

--- a/blender_addon_tester/addon_helper.py
+++ b/blender_addon_tester/addon_helper.py
@@ -103,14 +103,15 @@ def zip_addon(addon: str, addon_dir: str):
                 shutil.rmtree(temp_dir)
 
             # Creating the addon under the temp dir with its hierarchy 
-            shutil.copytree(addon_path, temp_dir.joinpath(addon_path.relative_to(addon_path.anchor)))
+            temp_dir_dst = temp_dir.joinpath(addon_path.relative_to(addon_path.anchor))
+            shutil.copytree(addon_path, temp_dir_dst)
 
             # Move to temp dir
-            os.chdir(temp_dir)
+            os.chdir(temp_dir_dst)
 
 
             # Write addon content into archive
-            for dirname, subdirs, files in os.walk(addon_path):
+            for dirname, subdirs, files in os.walk(temp_dir_dst):
                 for filename in files:
                     # Ignore pycache files
                     if filename.endswith('.pyc'):
@@ -123,7 +124,7 @@ def zip_addon(addon: str, addon_dir: str):
                         clean_file(filename)
 
                     # Write file into zip under its hierarchy
-                    zf.write(filename, arcname=os.path.relpath(filename, addon_path.parent))
+                    zf.write(filename, arcname=os.path.relpath(filename, temp_dir_dst.parent))
 
             # Go back to start dir
             os.chdir(cwd)

--- a/blender_addon_tester/addon_helper.py
+++ b/blender_addon_tester/addon_helper.py
@@ -108,17 +108,19 @@ def zip_addon(addon: str, addon_dir: str):
             # Move to temp dir
             os.chdir(temp_dir)
 
-            # Clear python cache
-            if os.path.isdir("__pycache__"):
-                shutil.rmtree("__pycache__")
 
             # Write addon content into archive
             for dirname, subdirs, files in os.walk(addon_path):
                 for filename in files:
+                    # Ignore pycache files
+                    if filename.endswith('.pyc'):
+                        continue
+
                     filename = os.path.join(dirname, filename)
 
                     # Clean file
-                    #clean_file(filename)
+                    if filename.endswith('.py'):
+                        clean_file(filename)
 
                     # Write file into zip under its hierarchy
                     zf.write(filename, arcname=os.path.relpath(filename, addon_path.parent))
@@ -133,7 +135,8 @@ def zip_addon(addon: str, addon_dir: str):
             #y = addon_path.as_posix()
             y = addon_basename
             #print(y)
-            clean_file(y)
+            if filename.endswith('.py'):
+                clean_file(y)
 
             # Write single addon file into zip
             zf.write(y)

--- a/blender_addon_tester/blender_load_pytest.py
+++ b/blender_addon_tester/blender_load_pytest.py
@@ -49,7 +49,7 @@ class SetupPlugin:
     def pytest_configure(self, config):
         (self.bpy_module, self.zfile) = zip_addon(self.addon, self.addon_dir)
         change_addon_dir(self.bpy_module, self.addon_dir)
-        install_addon(self.bpy_module, self.zfile)
+        install_addon(self.bpy_module, self.zfile, self.addon_dir)
         config.cache.set("bpy_module", self.bpy_module)
 
     def pytest_unconfigure(self):


### PR DESCRIPTION
- Compatible with Blender 3.6 and backwards compatible (3.6 allows the user to define multiple addon directories which broke the code)
- Prioritizes downloading Blender from
   - first https://ftp.nluug.nl/pub/graphics/blender/release/Blender
   - then https://builder.blender.org/download/daily
- Fixed using the temp directory to cleanup the addon (at first I removed but added it back later)
- Fixed cleaning pycache files and also considers pycache files in subdirectories